### PR TITLE
Linux Path and Special Characters in Config File

### DIFF
--- a/bin/srvconfig.py
+++ b/bin/srvconfig.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 class DMARCServiceConfig:
     config = None
-    _config_file_path = os.path.join(sys.path[0], "config\config.ini") 
+    _config_file_path = os.path.join(sys.path[0], "config", "config.ini") 
     start_datetime = ""
     ews_username = ""
     ews_password = ""
@@ -21,7 +21,7 @@ class DMARCServiceConfig:
     srv_max_worker = ""
     mailbox_type = ""
     _mailbox_type_ews = "ews"
-    error_log_path = os.path.join(sys.path[0], "log\error.log") 
+    error_log_path = os.path.join(sys.path[0], "log", "error.log") 
     error_log_enable = True
     debug_log_enable = False
     

--- a/bin/srvconfig.py
+++ b/bin/srvconfig.py
@@ -29,7 +29,7 @@ class DMARCServiceConfig:
     @staticmethod
     def init_config():
         try:
-            DMARCServiceConfig.config = configparser.ConfigParser()
+            DMARCServiceConfig.config = configparser.RawConfigParser()
             DMARCServiceConfig.config.read(DMARCServiceConfig._config_file_path)
             DMARCServiceConfig.start_datetime = DMARCServiceConfig.config['CONFIG']['start_datetime']
             DMARCServiceConfig.srv_max_worker = int(DMARCServiceConfig.config['CONFIG']['srv_max_worker'])


### PR DESCRIPTION
@mirrorofstripes Thank you for identifying the below:
- Use RawConfigParses instead of ConfigParses to avoid issues with parsing % character if present in password of mailbox.
- Update the os.path.join statements so that the script can run on Linux as well as Windows.